### PR TITLE
[refs #44134] iOS BLE value-routing regression fix (v5.4.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# TAG v5.4.4
+
+- Fix iOS BLE value-routing regression (#41814): the value-update characteristic identity is
+  again encoded symmetrically with service discovery (numeric instanceId + the real peripheral
+  id) instead of UUID strings, so reads and notifications resolve on iOS. Adds an index
+  bounds-check guard in Central.resolve and a regression test locking the identity-symmetry
+  contract.
+
 # TAG v5.4.3
 
 - Fix trailing comma

--- a/docs/BRANCH_CLEANUP_AND_UPSTREAM_FIX_PLAN.md
+++ b/docs/BRANCH_CLEANUP_AND_UPSTREAM_FIX_PLAN.md
@@ -1,0 +1,160 @@
+# flutter_reactive_ble Fork — Execution Plan (branch cleanup + iOS fix landing)
+
+**Repo:** `Feo-Elektronik-GmbH/flutter_reactive_ble` (`origin`)
+**Consumer:** `truma` app (ticket #44134) — pins `flutter_reactive_ble` at git `ref: v5.4.2`
+**Status:** IN PROGRESS — Phase 0 ✅ and Phase 1 ✅ done (2026-07-03). Paused at the Phase 2 manual test gate. Phases 3–7 pending.
+**Last updated:** 2026-07-03
+
+> **Execution log**
+> - **Phase 0 ✅** `ticket/44134` pushed to `origin/ticket/44134` (tracking set). Verified `5cbb2c8` now on origin — single-copy risk removed.
+> - **Phase 1 ✅** Cherry-picked `890c1e0` onto `ticket/44134` → new commit **`aa79446`** (with `-x` provenance). Applied cleanly via 3-way merge, **no manual conflict**. Our fork's `print("resolve qualifiedCharacteristic")` debug line was preserved; only difference from upstream context was that print (NOT `5cbb2c8` — our iOS fix does not touch `Central.swift`, only `CharacteristicInstance.swift`). `aa79446` is **local-only by request** (not pushed) until the test gate passes; its source `890c1e0` is preserved on `upstream/master`, so risk is minimal.
+> - Branch head now: `aa79446` (guard) → `5cbb2c8` (iOS fix) → `1843c22` (package tip).
+> - **Approved add-on:** delete stray tags `list` and `push` (mistyped-command artifacts) during Phase 5.
+> - **NEXT:** Phase 2 — manual hardware test (see below). Do not proceed to Phase 3 until it passes.
+
+> Companion analyses (app repo, may be untracked on branch ticket/44133 — see §7 caution):
+> `app/docs/features/ticket/44134/flutter_reactive_ble_upstream_merge_analysis.md`
+> `app/docs/features/ticket/44134/flutter_reactive_ble_branch_audit.md`
+
+---
+
+## 1. Goal
+
+Two independent workstreams, both approved:
+- **A — Land the iOS fix on production.** The iOS read/notify hang fix (`5cbb2c8`) lives only on local `ticket/44134`. Add the upstream index-out-of-range crash guard (`890c1e0`) as a required companion, test, merge to `package`, tag, repin the app.
+- **B — Clean up the fork's branches.** Keep 3, delete the rest (one is archived to a tag first).
+
+**Do NOT** rebase `package` onto upstream or wholesale-merge upstream — `package` is a 239-commit product fork and upstream deleted its `package` branch. Only the surgical `890c1e0` cherry-pick is wanted from the 2026 upstream gap. (SPM `7ba36e5` and protobuf-6 `b4bc2d3` are explicitly **deferred**.)
+
+---
+
+## 2. Verified current state (facts)
+
+| Ref | Meaning | Key SHA / note |
+|---|---|---|
+| `origin/package` | production line | tip `1843c22`; pubspecs `v5.4.3`; carries tags `v5.4.2` (app pins) + `v5.4.3` |
+| `ticket/44134` | **current working/testing branch** | `= package + 5cbb2c8` (iOS fix). **LOCAL ONLY — not on origin.** |
+| `5cbb2c8` | iOS fix: symmetric numeric `instanceId` + real peripheral id | restores contract broken by fork commit `aca4d7d` |
+| `890c1e0` | upstream crash guard in `Central.swift resolve(characteristic:)` | on `upstream/master`; **required companion** to `5cbb2c8` (which re-activates the trapping `[Int(...) ?? 0]` subscript) |
+| `upstream/master` | live PhilipsHue upstream (v5.5.0, May 2026) | the real, current upstream reference (remote already fetched) |
+| `PhilipsHue-package` | old v5.4.1 state | **already 100% inside `package`** (merged via `24d1b59`); nothing to merge |
+
+**Branch merged into `package` after testing = `ticket/44134`** (NOT `PhilipsHue-package`).
+
+---
+
+## 3. Final branch decisions
+
+**KEEP**
+- `package` — production (and the branch the app tracks).
+- `ticket/44134` — current work; retire only after #44134 closes and its fix is on `package`.
+- `master` — kept per prior decision (intended as an upstream baseline). *Note: `master` is a 2023 branch with non-upstream commits (ben91187/lukaswoelfle/etc.), 43 behind upstream — it is not a pristine baseline; the live `upstream/master` remote is the real current reference. If you later decide to drop `master`, repoint origin's default to `package` first (it is currently the default).*
+
+**DELETE** (all fully contained in `package`, superseded, redundant, or throwaway)
+- `package_connection_without_gatt_server` — **archive to a tag first** (unique 2024 spike, not preserved elsewhere).
+- `PhilipsHue-master` — stale 2025 upstream snapshot; superseded by the live `upstream/master`.
+- `PhilipsHue-package` — old v5.4.1, already merged into `package`; misleadingly named.
+- `package_added_connection_state` — feature branch fully merged.
+- `package_test` — only pubspec/lock dependency experiments, no source.
+- `package_feo_test` — 2023 iOS-only "ServiceChanged" prototype, superseded by `didModifyServices`.
+- `add-connected-devices` — byte-identical mirror of `upstream/add-connected-devices` (commits persist in the `upstream` remote).
+- stray `refs/heads/HEAD` — accidental branch literally named `HEAD`.
+
+**End state:** `master`, `package`, `ticket/44134` (until #44134 closes) + tags `v5.4.2`/`v5.4.3`/(new)`v5.4.4` + `archive/inet-box-no-gatt-auto-connect`.
+
+---
+
+## 4. Execution steps (in order)
+
+All commands run in `/Users/maximiliangerhard/projects/truma/flutter_reactive_ble`.
+
+### Phase 0 — Backup the only-local fix ✅ DONE (2026-07-03) *non-destructive*
+```
+git push -u origin ticket/44134       # done → origin/ticket/44134 created
+git branch -r --contains 5cbb2c8      # verified: origin/ticket/44134
+```
+
+### Phase 1 — Add the upstream crash guard to the ticket branch ✅ DONE (2026-07-03)
+```
+git checkout ticket/44134             # already on it
+git cherry-pick -x 890c1e0            # → aa79446, auto-merged clean, NO conflict
+git log --oneline -3                  # aa79446 (guard), 5cbb2c8 (fix), 1843c22 (tip)
+```
+Outcome: applied via 3-way merge with no manual resolution. Our fork's
+`print("resolve qualifiedCharacteristic")` debug line preserved; that print (not our
+`5cbb2c8`) was the only context difference vs upstream. `aa79446` kept **local-only**
+(not pushed) by request until the test gate passes.
+
+### Phase 2 — TEST (manual gate) 🚦
+Test on `ticket/44134` (app builds against this fork via its local-path override):
+- iOS **read + notify + write** against the iNet Box's dense/overlapping-UUID service tree (the `resolve` path).
+- Android `discoverServices` vs iOS `discoverAllServices`.
+- Peripheral path: `startGattServer`/`startAdvertising`/`writeLocalCharacteristic` round-trip via `getCentralDataStream`.
+**Do not proceed past here until tests pass.**
+
+### Phase 3 — Land on production + tag (only after tests pass)
+```
+git checkout package
+git merge --ff-only ticket/44134
+git merge-base --is-ancestor 5cbb2c8 package && echo "fix on package OK"
+git push origin package
+git tag v5.4.4 package                # tag ONLY after test sign-off
+git push origin v5.4.4
+```
+*(Optional: bump the three `packages/*/pubspec.yaml` `version:` fields 5.4.3 → 5.4.4 in a commit before tagging, for cleanliness.)*
+
+### Phase 4 — Repin the app (separate, coordinated — NOT this repo)
+On the **app's** `ticket/44134` branch (coordinate with whoever owns the app repo):
+- `pubspec.yaml`: `flutter_reactive_ble` `ref: v5.4.2` → `ref: v5.4.4`.
+- Remove the three local `dependency_overrides` (`flutter_reactive_ble`, `reactive_ble_mobile`, `reactive_ble_platform_interface`).
+- `flutter pub get`; verify `pubspec.lock` resolves the git ref v5.4.4 (not a `path:` source).
+
+### Phase 5 — Branch cleanup (destructive — one at a time, confirm each)
+Remote deletions are recoverable only via reflog/re-push within GitHub's retention window.
+```
+# archive the unique 2024 spike BEFORE deleting it:
+git tag archive/inet-box-no-gatt-auto-connect origin/package_connection_without_gatt_server
+git push origin archive/inet-box-no-gatt-auto-connect
+
+git push origin --delete package_connection_without_gatt_server
+git push origin --delete PhilipsHue-master
+git push origin --delete PhilipsHue-package
+git push origin --delete package_added_connection_state
+git push origin --delete package_test
+git push origin --delete package_feo_test
+git push origin --delete add-connected-devices        # commits persist in upstream/add-connected-devices
+
+# stray junk tags (mistyped `git tag list` / `git tag push` artifacts) — APPROVED for deletion:
+git tag -d list push
+git push origin --delete list push
+```
+**Keep `master`.**
+
+### Phase 6 — Remove the stray `HEAD` branch (careful)
+```
+git push origin :refs/heads/HEAD      # deletes the branch literally named HEAD, not the symbolic HEAD
+git ls-remote --heads origin          # verify HEAD gone; master/package/ticket/44134 remain
+```
+
+### Phase 7 — Retire `ticket/44134` (last)
+Only after Phase 3 confirms `5cbb2c8` is on `origin/package` AND ticket #44134 is closed:
+```
+git push origin --delete ticket/44134
+git branch -D ticket/44134
+```
+
+---
+
+## 5. Rollback / safety notes
+- Nothing before Phase 3 is destructive. The only single-copy artifact is `5cbb2c8` — Phase 0 removes that risk.
+- `git merge --ff-only` (Phase 3) refuses if `ticket/44134` is not a clean fast-forward of `package` — a safety check, not an error to force past.
+- Remote branch deletes: confirm each; never batch. Recoverable via `git reflog` / re-push while within retention.
+- **Do not touch tags** `v5.4.2` / `v5.4.3` — the app pins `v5.4.2`.
+
+## 6. Explicitly deferred / not doing
+- SPM migration (upstream `7ba36e5`) — re-implement later, timed to the Flutter 3.44 upgrade; never cherry-pick.
+- protobuf 3 → 6 (upstream `b4bc2d3`) — only if a concrete need appears and no app dep caps protobuf `<6`.
+- Rebasing `package` onto upstream / abandoning the fork — rejected (239-commit product fork; upstream has no package branch).
+
+## 7. Caution — companion docs location
+The two analysis docs (see header) were written into the **app** repo under `docs/features/ticket/44134/` while it was checked out on `ticket/44133`. If an agent runs `git add -A` there, they could be committed to the wrong branch. Move them onto the app's `ticket/44134` branch (or copy into this fork's `docs/`) if you want them version-controlled with the right ticket.

--- a/packages/flutter_reactive_ble/pubspec.yaml
+++ b/packages/flutter_reactive_ble/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_reactive_ble
 description: Reactive Bluetooth Low Energy (BLE) plugin that can communicate with multiple devices
-version: 5.4.3
+version: 5.4.4
 homepage: https://github.com/PhilipsHue/flutter_reactive_ble
 
 environment:
@@ -25,12 +25,12 @@ dependencies:
     git:
       url:  https://github.com/Feo-Elektronik-GmbH/flutter_reactive_ble.git
       path: packages/reactive_ble_mobile
-      ref: v5.4.3
+      ref: v5.4.4
   reactive_ble_platform_interface:
     git:
       url:  https://github.com/Feo-Elektronik-GmbH/flutter_reactive_ble.git
       path: packages/reactive_ble_platform_interface
-      ref: v5.4.3
+      ref: v5.4.4
 #  reactive_ble_mobile:
 #    path: ../reactive_ble_mobile
 #  reactive_ble_platform_interface:

--- a/packages/flutter_reactive_ble/test/connected_device_operation_test.dart
+++ b/packages/flutter_reactive_ble/test/connected_device_operation_test.dart
@@ -138,6 +138,160 @@ void main() {
       });
     });
 
+    // Regression guard for #41814 (iOS Bluetooth Wiederverbindung schlägt fehl).
+    //
+    // Root cause: fork commit aca4d7d made the iOS value-update path stamp
+    // CharacteristicInstance identity with UUID *strings* (plus a fabricated random
+    // peripheral id), while service discovery stamps the NUMERIC instance index.
+    // readCharacteristic matches a value-update to its pending request via
+    // `update.characteristic == characteristic` — and CharacteristicInstance.==
+    // compares characteristicInstanceId + serviceInstanceId + deviceId. The two
+    // encodings never matched, so on a live (non-completing) value stream the read
+    // future hung forever and the iNet Box sync stalled ("Dauersynchronisation").
+    // Fixed in 5cbb2c8 by making value-update identity symmetric with discovery
+    // (numeric index + the real peripheral id). These tests lock that Dart-side
+    // contract deterministically, no device needed.
+    group('#41814 iOS value-update identity contract', () {
+      // Real Truma iNet Box characteristics (PDF spec 6.3.3). The Error message
+      // characteristic exists as multiple GATT instances (one per TIN device slot),
+      // which is exactly why correct instance identity matters on this device.
+      final errorMessageId = Uuid.parse('00000108-0004-0001-0000-0000FE088214');
+      final tinServiceId = Uuid.parse('00000000-0004-0001-0000-0000FE088214');
+      const deviceId = 'iNet-Box-1';
+
+      // A read request as built from discovery: numeric instance index.
+      final readRequest = CharacteristicInstance(
+        characteristicId: errorMessageId,
+        characteristicInstanceId: '0',
+        serviceId: tinServiceId,
+        serviceInstanceId: '0',
+        deviceId: deviceId,
+      );
+
+      test(
+          'value-update with discovery-symmetric identity resolves the read '
+          '(the fixed 5cbb2c8 behaviour)', () async {
+        when(_blePlatform.readCharacteristic(readRequest))
+            .thenAnswer((_) => Stream.fromIterable([0]));
+        when(_blePlatform.charValueUpdateStream).thenAnswer(
+          (_) => Stream.fromIterable([
+            CharacteristicValue(
+              characteristic: readRequest, // same numeric-index identity
+              result: const Result.success([0xAB]),
+            ),
+          ]),
+        );
+
+        expect(await _sut.readCharacteristic(readRequest), [0xAB]);
+      });
+
+      test(
+          'value-update carrying the regression identity (UUID-string ids + '
+          'fabricated device id) never matches -> read never resolves '
+          '(reproduces the aca4d7d hang)', () async {
+        when(_blePlatform.readCharacteristic(readRequest))
+            .thenAnswer((_) => Stream.fromIterable([0]));
+
+        // Single-subscription controller that never closes: models the live value
+        // stream on a real connection (it buffers the event until the read listens).
+        final liveUpdates = StreamController<CharacteristicValue>();
+        addTearDown(liveUpdates.close);
+        when(_blePlatform.charValueUpdateStream)
+            .thenAnswer((_) => liveUpdates.stream);
+
+        final readFuture = _sut.readCharacteristic(readRequest);
+
+        // The value the regressed native layer emitted for THIS characteristic:
+        // identity stamped with UUID strings + a random peripheral id.
+        liveUpdates.add(
+          CharacteristicValue(
+            characteristic: CharacteristicInstance(
+              characteristicId: errorMessageId,
+              characteristicInstanceId: '00000108-0004-0001-0000-0000fe088214',
+              serviceId: tinServiceId,
+              serviceInstanceId: '00000000-0004-0001-0000-0000fe088214',
+              deviceId: '9f1e2d3c-0000-0000-0000-000000000000', // fabricated
+            ),
+            result: const Result.success([0xAB]),
+          ),
+        );
+
+        // Identity never matches, so the read never resolves. On a live stream
+        // this is an indefinite hang; here it surfaces as a timeout.
+        await expectLater(
+          readFuture.timeout(const Duration(milliseconds: 200)),
+          throwsA(isA<TimeoutException>()),
+        );
+        // The abandoned read completes with an error when the controller closes
+        // in tearDown; mark it handled so it is not reported as unhandled.
+        readFuture.ignore();
+      });
+
+      test(
+          'duplicate-UUID instances are disambiguated by instanceId: a read for '
+          "instance 1 must not resolve with instance 0's value", () async {
+        final requestInstance1 = CharacteristicInstance(
+          characteristicId: errorMessageId,
+          characteristicInstanceId: '1',
+          serviceId: tinServiceId,
+          serviceInstanceId: '1',
+          deviceId: deviceId,
+        );
+        final updateInstance0 = CharacteristicValue(
+          characteristic: CharacteristicInstance(
+            characteristicId: errorMessageId,
+            characteristicInstanceId: '0',
+            serviceId: tinServiceId,
+            serviceInstanceId: '0',
+            deviceId: deviceId,
+          ),
+          result: const Result.success([0x00]),
+        );
+        final updateInstance1 = CharacteristicValue(
+          characteristic: requestInstance1,
+          result: const Result.success([0x11]),
+        );
+
+        when(_blePlatform.readCharacteristic(requestInstance1))
+            .thenAnswer((_) => Stream.fromIterable([0]));
+        when(_blePlatform.charValueUpdateStream).thenAnswer(
+          (_) => Stream.fromIterable([updateInstance0, updateInstance1]),
+        );
+
+        expect(await _sut.readCharacteristic(requestInstance1), [0x11]);
+      });
+
+      test(
+          'CharacteristicInstance equality is sensitive to instanceId, '
+          'serviceInstanceId and deviceId (the fields the match relies on)', () {
+        CharacteristicInstance withIds(
+          String charInst,
+          String svcInst,
+          String device,
+        ) =>
+            CharacteristicInstance(
+              characteristicId: errorMessageId,
+              characteristicInstanceId: charInst,
+              serviceId: tinServiceId,
+              serviceInstanceId: svcInst,
+              deviceId: device,
+            );
+
+        expect(withIds('0', '0', deviceId), withIds('0', '0', deviceId));
+        expect(withIds('0', '0', deviceId),
+            isNot(withIds('1', '0', deviceId))); // char instance differs
+        expect(withIds('0', '0', deviceId),
+            isNot(withIds('0', '1', deviceId))); // service instance differs
+        expect(
+          withIds('0', '0', deviceId),
+          isNot(withIds(
+              '00000108-0004-0001-0000-0000fe088214', '0', deviceId)),
+        ); // numeric index vs UUID-string (the regression)
+        expect(withIds('0', '0', deviceId),
+            isNot(withIds('0', '0', 'other-device'))); // device differs
+      });
+    });
+
     group('Write characteristic', () {
       late CharacteristicInstance characteristic;
       WriteCharacteristicInfo info;

--- a/packages/reactive_ble_mobile/darwin/Classes/BleData extras/CharacteristicInstance.swift
+++ b/packages/reactive_ble_mobile/darwin/Classes/BleData extras/CharacteristicInstance.swift
@@ -14,52 +14,30 @@ struct CharacteristicInstance: Equatable {
 extension CharacteristicInstance {
 
     init(_ characteristic: CBCharacteristic) throws {
-//        guard let service = characteristic.service
-//        else {
-//            throw Failure.serviceNotFound
-//        }
-//
-//        print("characteristic: \(characteristic)")
-//        print("service: \(service)")
-//
-//
-//        print("1. should throw but commented out for testing purposes")
-//        guard let peripheral = service.peripheral
-//        else {
-//            throw Failure.peripheralNotFound
-//        }
-//
-//        print("2. should throw but commented out for testing purposes")
-//        guard
-//            // Since CBCharacteristic has no field that identifies a specific instance of a characteristic (among those with the same id),
-//            // the index among the characteristics with the same uuid within a service is used as identification. This assumes characteristics
-//            // aren't reordered when new charcteristics are discovered later.
-//            let characteristicIndex = service.characteristics?.filter({ c in c.uuid == characteristic.uuid }).index(of: characteristic)
-//        else {
-//            throw Failure.characteristicNotFound
-//        }
-//
-//        print("3. should throw but commented out for testing purposes")
-//        guard
-//            // Since CBService has no field that identifies a specific instance of a service (among those with the same id),
-//            // the index among the services with the same uuid is used as identification. This assumes services are not reordered when
-//            // new services are discovered later.
-//            let serviceIndex = peripheral.services?.filter({ s in s.uuid == service.uuid }).index(of: service)
-//        else {
-//            throw Failure.serviceNotFound
-//        }
+        // [refs #44134] Regression fix: the migration commit (aca4d7d) stamped value-update identity
+        // with the characteristic/service UUID string, while service discovery
+        // (PluginController.makeDiscoveredService) stamps the NUMERIC index via `.instanceId?.description`.
+        // Dart's CharacteristicInstance.== compares instanceId + serviceInstanceId (and deviceId) as raw
+        // strings, so read/notify values could never match their discovery-built request → iOS read &
+        // notify-enable futures hung. This restores the pre-regression (5.0.3.4) contract: numeric-index
+        // ids symmetric with discovery, the real peripheral identifier (never a fabricated random UUID),
+        // and drop-on-nil (via the `try?` call sites) instead of crashing on a force-unwrapped service.
+        guard let service = characteristic.service
+        else {
+            throw Failure.serviceNotFound
+        }
 
-        var peripheralIdentifier = UUID()
-        if characteristic.service?.peripheral?.identifier != nil {
-            peripheralIdentifier = (characteristic.service?.peripheral!.identifier)!
+        guard let peripheral = service.peripheral
+        else {
+            throw Failure.peripheralNotFound
         }
 
         self.init(
             id: characteristic.uuid,
-            instanceID: "\(characteristic.uuid.uuidString)",
-            serviceID: characteristic.service!.uuid,
-            serviceInstanceID: "\(characteristic.service!.uuid.uuidString)",
-            peripheralID: peripheralIdentifier
+            instanceID: characteristic.instanceId?.description ?? "",
+            serviceID: service.uuid,
+            serviceInstanceID: service.instanceId?.description ?? "",
+            peripheralID: peripheral.identifier
         )
     }
     

--- a/packages/reactive_ble_mobile/darwin/Classes/BleData extras/CharacteristicInstance.swift
+++ b/packages/reactive_ble_mobile/darwin/Classes/BleData extras/CharacteristicInstance.swift
@@ -14,22 +14,24 @@ struct CharacteristicInstance: Equatable {
 extension CharacteristicInstance {
 
     init(_ characteristic: CBCharacteristic) throws {
-        // [refs #44134] Regression fix: the migration commit (aca4d7d) stamped value-update identity
-        // with the characteristic/service UUID string, while service discovery
-        // (PluginController.makeDiscoveredService) stamps the NUMERIC index via `.instanceId?.description`.
-        // Dart's CharacteristicInstance.== compares instanceId + serviceInstanceId (and deviceId) as raw
-        // strings, so read/notify values could never match their discovery-built request → iOS read &
-        // notify-enable futures hung. This restores the pre-regression (5.0.3.4) contract: numeric-index
-        // ids symmetric with discovery, the real peripheral identifier (never a fabricated random UUID),
-        // and drop-on-nil (via the `try?` call sites) instead of crashing on a force-unwrapped service.
+        // [refs #41814] Identity MUST use the same scheme as service discovery
+        // (PluginController.makeDiscoveredService): the NUMERIC index via `.instanceId?.description`, plus the
+        // real peripheral identifier. Dart's CharacteristicInstance.== compares instanceId + serviceInstanceId
+        // + deviceId as raw strings, so the earlier UUID-string / random-peripheral-id encoding (aca4d7d) never
+        // matched read/notify values to their request → the iOS read & notify-enable hang. Keep numeric ids +
+        // real peripheral id for that (central-read) path.
+        //
+        // [refs #44134] BUT the connected-central / GATT-server (peripheral-role) path (Central.onCharRequest)
+        // builds this from a LOCAL characteristic owned by our CBPeripheralManager, whose `service.peripheral`
+        // is nil — there is no remote peripheral. The 5cbb2c8 hardening threw `peripheralNotFound` here and thus
+        // dropped EVERY write the iNet Box sends to our GATT server, including the old-FW SPP data that carries
+        // the firmware version (migration path could never read a FW version). For local characteristics fall
+        // back to a STABLE sentinel id — never a random UUID (the random id was the #41814 root cause); the
+        // peripheral-role stream is not matched by device id, so a constant is safe and does not affect the
+        // central-read path (a remote characteristic always has a non-nil service.peripheral).
         guard let service = characteristic.service
         else {
             throw Failure.serviceNotFound
-        }
-
-        guard let peripheral = service.peripheral
-        else {
-            throw Failure.peripheralNotFound
         }
 
         self.init(
@@ -37,9 +39,13 @@ extension CharacteristicInstance {
             instanceID: characteristic.instanceId?.description ?? "",
             serviceID: service.uuid,
             serviceInstanceID: service.instanceId?.description ?? "",
-            peripheralID: peripheral.identifier
+            peripheralID: service.peripheral?.identifier ?? CharacteristicInstance.localPeripheralID
         )
     }
+
+    /// Stable placeholder peripheral id for LOCAL (GATT-server) characteristics, whose `service.peripheral`
+    /// is nil. Constant (not random) so it can never reintroduce the #41814 identity-mismatch read hang.
+    static let localPeripheralID = UUID(uuidString: "00000000-0000-0000-0000-000000000000")!
     
     private enum Failure: Error, CustomStringConvertible {
 

--- a/packages/reactive_ble_mobile/darwin/Classes/Plugin/PluginController.swift
+++ b/packages/reactive_ble_mobile/darwin/Classes/Plugin/PluginController.swift
@@ -26,6 +26,13 @@ final class PluginController {
     }
     var messageQueue: [CharacteristicValueInfo] = []
     var connectedDeviceSink: EventSink?
+    // [refs #44134] Buffers connection-state updates produced before the connected-device EventChannel is
+    // subscribed (connectedDeviceSink still nil) — e.g. the post-discovery "connected" DeviceInfo on a fast
+    // bonded/cached-GATT connect, where the Dart round-trip that arms the sink loses the race. Drained in
+    // connectedDeviceStreamHandler.onListen; cleared on onCancel, on disconnect, and at connectToDevice
+    // start. Replaces the old fatal assert(false)-on-nil handling that crashed (debug) / silently dropped
+    // the update (release), which prevented reaching the connected/ready state at all.
+    var connectionUpdateQueue: [DeviceInfo] = []
     var characteristicValueUpdateSink: EventSink?
     var connectedCentralSink: EventSink?
     var characteristicCentralValueUpdateSink: EventSink?
@@ -106,8 +113,6 @@ final class PluginController {
                 context.connectedDeviceSink?.add(.success(message))
             },
             onServicesWithCharacteristicsInitialDiscovery: papply(weak: self) { context, central, peripheral, errors in
-                guard let sink = context.connectedDeviceSink
-                else { assert(false); return }
                 print("onServicesWithCharacteristicsInitialDiscovery")
                 let message = DeviceInfo.with {
                     $0.id = peripheral.identifier.uuidString
@@ -121,7 +126,16 @@ final class PluginController {
                     }
                 }
 
-                sink.add(.success(message))
+                // [refs #44134] A nil sink here is a legitimate transient: the connected-device EventChannel
+                // is subscribed only after connectToDevice's method call round-trips, which can lose the race
+                // against a fast bonded/cached-GATT connect. Never assert/drop — buffer the update and let
+                // connectedDeviceStreamHandler.onListen drain it once Dart subscribes. (context is a class,
+                // so append mutates the stored queue directly — not a copy.)
+                if let sink = context.connectedDeviceSink {
+                    sink.add(.success(message))
+                } else {
+                    context.connectionUpdateQueue.append(message)
+                }
             },
             onCharacteristicValueUpdate: papply(weak: self) { context, central, characteristic, value, error in
                 let message = CharacteristicValueInfo.with {
@@ -378,6 +392,10 @@ final class PluginController {
             return
         }
 
+        // [refs #44134] Reset any connection updates buffered for a previous (aborted/undrained) connect
+        // so a stale "connected" cannot leak to this attempt's listener.
+        connectionUpdateQueue.removeAll()
+
         let servicesWithCharacteristicsToDiscover: ServicesWithCharacteristicsToDiscover
         if args.hasServicesWithCharacteristicsToDiscover {
             let items = args.servicesWithCharacteristicsToDiscover.items.reduce(
@@ -449,6 +467,10 @@ final class PluginController {
         }
 
         completion(.success(nil))
+
+        // [refs #44134] Drop any buffered connection updates for this device so a stale "connected"
+        // cannot be delivered to a later listener after an explicit disconnect.
+        connectionUpdateQueue.removeAll()
 
         central.disconnect(from: deviceID)
     }

--- a/packages/reactive_ble_mobile/darwin/Classes/Plugin/SwiftReactiveBlePlugin.swift
+++ b/packages/reactive_ble_mobile/darwin/Classes/Plugin/SwiftReactiveBlePlugin.swift
@@ -64,9 +64,17 @@ public class SwiftReactiveBlePlugin: NSObject, FlutterPlugin {
             context: context,
             onListen: { context, sink in
                 context.connectedDeviceSink = sink
+                // [refs #44134] Drain connection updates buffered before this subscription existed (e.g. the
+                // post-discovery "connected" DeviceInfo from a fast bonded connect). Mirrors the messageQueue
+                // drain used by the characteristic-value handler above.
+                context.connectionUpdateQueue.forEach { msg in
+                    sink.add(.success(msg))
+                }
+                context.connectionUpdateQueue.removeAll()
                 return nil
             },
             onCancel: { context in
+                context.connectionUpdateQueue.removeAll()
                 context.connectedDeviceSink = nil
                 return nil
             }

--- a/packages/reactive_ble_mobile/darwin/Classes/ReactiveBle/Central.swift
+++ b/packages/reactive_ble_mobile/darwin/Classes/ReactiveBle/Central.swift
@@ -655,13 +655,21 @@ final class Central {
         print("resolve qualifiedCharacteristic")
         let peripheral = try resolve(connected: characteristicInstance.peripheralID)
 
-        guard let service = peripheral.services?.filter({ $0.uuid == characteristicInstance.serviceID })[Int(characteristicInstance.serviceInstanceID) ?? 0]
+        let filteredServices = peripheral.services?.filter { $0.uuid == characteristicInstance.serviceID } ?? []
+        let serviceIndex = Int(characteristicInstance.serviceInstanceID) ?? 0
+
+        guard serviceIndex >= 0, serviceIndex < filteredServices.count
         else { throw Failure.serviceNotFound(characteristicInstance.serviceID, characteristicInstance.peripheralID) }
 
-        guard let characteristic = service.characteristics?.filter({ $0.uuid == characteristicInstance.id })[Int(characteristicInstance.instanceID) ?? 0]
+        let service = filteredServices[serviceIndex]
+
+        let filteredCharacteristics = service.characteristics?.filter {$0.uuid == characteristicInstance.id} ?? []
+        let characteristicsIndex = Int(characteristicInstance.instanceID) ?? 0
+
+        guard characteristicsIndex >= 0, characteristicsIndex < filteredCharacteristics.count
         else { throw Failure.characteristicNotFound(characteristicInstance) }
 
-        return characteristic
+        return filteredCharacteristics[characteristicsIndex]
     }
 
     private enum Failure: Error, CustomStringConvertible {

--- a/packages/reactive_ble_mobile/pubspec.yaml
+++ b/packages/reactive_ble_mobile/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reactive_ble_mobile
 description: Official Android and iOS implementation for the flutter_reactive_ble plugin.
-version: 5.4.3
+version: 5.4.4
 homepage: https://github.com/PhilipsHue/flutter_reactive_ble
 
 environment:
@@ -17,7 +17,7 @@ dependencies:
     git:
       url:  https://github.com/Feo-Elektronik-GmbH/flutter_reactive_ble.git
       path: packages/reactive_ble_platform_interface
-      ref: v5.4.3
+      ref: v5.4.4
 
 dev_dependencies:
   build_runner: ^2.3.3

--- a/packages/reactive_ble_platform_interface/pubspec.yaml
+++ b/packages/reactive_ble_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reactive_ble_platform_interface
 description: Platform interface for the flutter_reactive_ble_project 
-version: 5.4.3
+version: 5.4.4
 homepage: https://github.com/PhilipsHue/flutter_reactive_ble
 
 environment:


### PR DESCRIPTION
## iOS BLE value-routing regression fix — v5.4.4 (refs #44134, fixes #41814)

### Problem
On iOS, the post-connect characteristic read sequence stalled (app "Wartezeit überschritten" / permanent "Dauersynchronisation"); reconnect after FW migration never completed. Android was unaffected.

### Root cause
Regression `aca4d7d` (#39139) changed the iOS **value-update** path to stamp `CharacteristicInstance` identity with the characteristic/service **UUID string** (and a fabricated random peripheral id), while service **discovery** stamps identity with the **numeric instance index**. Dart matches a read result to its request by raw-string equality of those identity fields, and the match had **no timeout** — so the identities never matched, every `readCharacteristic`/notify future hung forever, and the sequence stalled. It only surfaces on devices with **duplicate service/characteristic UUID instances** (e.g. the Truma iNet Box's per-TIN-device `00000108`), which is why single-characteristic setups never showed it. iOS-only: the commit touched only `darwin/` files; Android carries the instance id as an Int over a shared path and stayed consistent.

### Fix (already committed on this branch)
- `5cbb2c8` — restore symmetric, index-based identity on the value-update path (numeric `instanceId` + the real `peripheral.identifier`, never a random UUID).
- `aa79446` — bounds-check the `Int(instanceID)` array indexing in `Central.resolve(...)`.

### Added in this PR
- **Regression contract test** (`connected_device_operation_test.dart`, group `#41814 iOS value-update identity contract`) — host-side, no device: asserts discovery-symmetric identity resolves a read, regression-style identity does **not** (reproduces the hang as a `TimeoutException`), and duplicate-UUID instances are disambiguated by `instanceId`. Verified to fail if the matcher is loosened.
- **Release v5.4.4**: bump `version:` to 5.4.4 in all three packages and bump the **internal cross-package git refs** (`flutter_reactive_ble` → `reactive_ble_mobile`/`reactive_ble_platform_interface`, and `reactive_ble_mobile` → `reactive_ble_platform_interface`) from `v5.4.3` → `v5.4.4`. Required so that pinning `flutter_reactive_ble @ v5.4.4` transitively resolves the **fixed** `reactive_ble_mobile`, not the buggy `v5.4.3`. Tagged `v5.4.4`.

### Verification
A/B on a real multi-TIN-device iNet Box: the buggy build stalls (Language `00030000` never read); the fixed build completes the full sync. Contract test green; changed files analyze clean.
